### PR TITLE
Updated codes.tsv with Glottolog information

### DIFF
--- a/codes.tsv
+++ b/codes.tsv
@@ -1,187 +1,187 @@
-ISO 639-3	Code	Language name(s)	Script	Locale	Ethnologue	Variety
-ace	ace	Acehnese	Latin	Indonesia	https://www.ethnologue.com/language/ace	
-afr	afr	Afrikaans	Latin	South Africa	https://www.ethnologue.com/language/afr	
-aka	aka_akuapem	Akan	Latin	Ghana	https://www.ethnologue.com/language/aka	Akuapem
-aka	aka_asante	Akan	Latin	Ghana	https://www.ethnologue.com/language/aka	Asante
-amh	amh	Amharic	Ethiopic	Ethiopia	https://www.ethnologue.com/language/amh	
-arb	arb	Arabic (MSA)	Arabic	World	https://www.ethnologue.com/language/arb	Modern Standard
-ary	ary_no_diacritics	Arabic	Arabic	Morocco	https://www.ethnologue.com/language/ary	without diacritics
-ary	ary_with_diacritics	Arabic	Arabic	Morocco	https://www.ethnologue.com/language/ary	with diacritics
-arz	arz	Arabic	Arabic	Egypt	https://www.ethnologue.com/language/arz	
-asm	asm	Assamese	Bengali	India	https://www.ethnologue.com/language/asm	
-awa	awa	Awadhi	Devanagari	India	https://www.ethnologue.com/language/awa	
-aze	aze_az	Azerbaijani	Latin	Azerbaijan	https://www.ethnologue.com/language/aze	
-aze	aze_ir	Azerbaijani	Arabic	Iran, Islamic Republic of	https://www.ethnologue.com/language/aze	
-bam	bam	Bambara	Latin	Mali	https://www.ethnologue.com/language/bam	
-ban	ban	Balinese	Latin	Indonesia	https://www.ethnologue.com/language/ban	
-bar	bar	Bavarian	Latin	Austria	https://www.ethnologue.com/language/bar	
-bbc	bbc	Batak Toba	Latin	Indonesia	https://www.ethnologue.com/language/bbc	
-bel	bel	Belarusian, Belarusan	Cyrillic	Belarus	https://www.ethnologue.com/language/bel	
-ben	ben	Bengali	Bengali	Bangladesh	https://www.ethnologue.com/language/ben	
-bgc	bgc	Haryanvi	Devanagari	India	https://www.ethnologue.com/language/bgc	
-bgn	bgn	Balochi, Baluchi	Arabic	Pakistan	https://www.ethnologue.com/language/bgn	
-bho	bho	Bhojpuri	Devanagari	India	https://www.ethnologue.com/language/bho	
-bjn	bjn	Banjar	Latin	Indonesia	https://www.ethnologue.com/language/bjn	
-bmw	bmw	Norwegian Bokmål	Latin	Norway	https://www.ethnologue.com/language/bmw	
-bod	bod	Tibetan	Tibetan	China	https://www.ethnologue.com/language/bod	
-boy	boy	Bodo	Devanagari	India	https://www.ethnologue.com/language/boy	
-bug	bug	Buginese	Latin	Indonesia	https://www.ethnologue.com/language/bug	
-bul	bul	Bulgarian	Cyrillic	Bulgaria	https://www.ethnologue.com/language/bul	
-cat	cat_es	Catalan	Latin	Spain	https://www.ethnologue.com/language/cat	
-cat	cat_valencia	Catalan	Latin	Valencia	https://www.ethnologue.com/language/cat	
-ceb	ceb_austronesian	Cebuano	Latin	Philippines	https://www.ethnologue.com/language/ceb	Austronesian
-ceb	ceb_spanish	Cebuano	Latin	Philippines	https://www.ethnologue.com/language/ceb	Spanish
-ces	ces	Czech	Latin	Czechia	https://www.ethnologue.com/language/ces	
-ckb	ckb_arabic	Sorani, Kurdish	Arabic	Iraq	https://www.ethnologue.com/language/ckb	
-ckb	ckb_latin	Sorani, Kurdish	Latin	Iraq	https://www.ethnologue.com/language/ckb	
-cmn	cmn_simplified	Chinese, Mandarin, Mandarin Chinese	Han (Simplified variant)	China	https://www.ethnologue.com/language/cmn	
-cmn	cmn_traditional	Taiwanese Mandarin	Han (Traditional variant)	Taiwan	https://www.ethnologue.com/language/cmn	
-cos	cos	Corsican	Latin	France	https://www.ethnologue.com/language/cos	
-ctg	ctg	Chittagonian	Bengali	Bangladesh	https://www.ethnologue.com/language/ctg	
-cym	cym	Welsh	Latin	United Kingdom	https://www.ethnologue.com/language/cym	
-dan	dan	Danish	Latin	Denmark	https://www.ethnologue.com/language/dan	
-dcc	dcc	Deccan	Arabic	India	https://www.ethnologue.com/language/dcc	
-deu	deu	German	Latin	Germany	https://www.ethnologue.com/language/deu	
-dgo	dgo	Dogri	Devanagari	India	https://www.ethnologue.com/language/dgo	
-dzo	dzo	Dzongkha	Tibetan	Bhutan	https://www.ethnologue.com/language/dzo	
-ell	ell	Greek	Greek	Greece	https://www.ethnologue.com/language/ell	
-eng	eng_in	English	Latin	India	https://www.ethnologue.com/language/eng	
-eng	eng_us	English	Latin	United States of America	https://www.ethnologue.com/language/eng	
-epo	epo	Esperanto	Latin	World	https://www.ethnologue.com/language/epo	
-est	est	Estonian	Latin	Estonia	https://www.ethnologue.com/language/est	
-eus	eus	Basque	Latin	Spain	https://www.ethnologue.com/language/eus	
-fil	fil	Tagalog	Latin	Philippines	https://www.ethnologue.com/language/tgl	
-fin	fin	Finnish	Latin	Finland	https://www.ethnologue.com/language/fin	
-fra	fra_ch	French	Latin	Switzerland	https://www.ethnologue.com/language/fra	
-fra	fra_fr	French	Latin	France	https://www.ethnologue.com/language/fra	
-fry	fry	Western Frisian	Latin	Netherlands	https://www.ethnologue.com/language/fry	
-ful	ful	Fulah	Latin	West Africa	https://www.ethnologue.com/language/ful	
-gla	gla	Scottish Gaelic	Latin	United Kingdom	https://www.ethnologue.com/language/gla	
-gle	gle	Irish	Latin	Ireland	https://www.ethnologue.com/language/gle	
-glg	glg	Galician	Latin	Spain	https://www.ethnologue.com/language/glg	
-grn	grn	Guarani, Guaraní	Latin	Paraguay	https://www.ethnologue.com/language/grn	
-guj	guj	Gujarati	Gujarati	India	https://www.ethnologue.com/language/guj	
-hat	hat	Haitian	Latin	Haiti	https://www.ethnologue.com/language/hat	
-hau	hau	Hausa	Latin	Nigeria	https://www.ethnologue.com/language/hau	
-haw	haw	Hawaiian	Latin	United States of America	https://www.ethnologue.com/language/haw	
-heb	heb_no_diacritics	Hebrew	Hebrew	Israel	https://www.ethnologue.com/language/heb	without diacritics
-heb	heb_with_diacritics	Hebrew	Hebrew	Israel	https://www.ethnologue.com/language/heb	with diacritics
-hil	hil	Hiligaynon	Latin	Philippines	https://www.ethnologue.com/language/hil	
-hin	hin	Hindi	Devanagari	India	https://www.ethnologue.com/language/hin	
-hmn	hmn	Hmong	Latin	China	https://www.ethnologue.com/language/hmn	
-hne	hne	Chhattisgarhi	Devanagari	India	https://www.ethnologue.com/language/hne	
-hoj	hoj	Harauti	Devanagari	India	https://www.ethnologue.com/language/hoj	
-hrv	hrv	Croatian	Latin	Croatia	https://www.ethnologue.com/language/hrv	
-hun	hun	Hungarian	Latin	Hungary	https://www.ethnologue.com/language/hun	
-hye	hye	Armenian	Armenian	Armenia	https://www.ethnologue.com/language/hye	
-ibo	ibo	Igbo	Latin	Nigeria	https://www.ethnologue.com/language/ibo	
-ilo	ilo	Ilocano, Iloko	Latin	Philippines	https://www.ethnologue.com/language/ilo	
-ind	ind	Indonesian	Latin	Indonesia	https://www.ethnologue.com/language/ind	
-isl	isl	Icelandic	Latin	Iceland	https://www.ethnologue.com/language/isl	
-ita	ita	Italian	Latin	Italy	https://www.ethnologue.com/language/ita	
-jav	jav	Javanese	Latin	Indonesia	https://www.ethnologue.com/language/jav	
-jpn	jpn	Japanese	Japanese	Japan	https://www.ethnologue.com/language/jpn	
-kan	kan	Kannada	Kannada	India	https://www.ethnologue.com/language/kan	
-kas	kas	Kashmiri	Devanagari	India	https://www.ethnologue.com/language/kas	
-kat	kat	Georgian	Georgian	Georgia	https://www.ethnologue.com/language/kat	
-kaz	kaz	Kazakh	Cyrillic	Kazakhstan	https://www.ethnologue.com/language/kaz	
-khm	khm	Khmer, Central Khmer	Khmer	Cambodia	https://www.ethnologue.com/language/khm	
-kin	kin	Kinyarwanda	Latin	Rwanda	https://www.ethnologue.com/language/kin	
-kir	kir	Kyrgyz, Kirghiz	Cyrillic	Kyrgyzstan	https://www.ethnologue.com/language/kir	
-kok	kok	Konkani	Devanagari	India	https://www.ethnologue.com/language/kok	
-kor	kor	Korean	Hangul	Korea, Republic of	https://www.ethnologue.com/language/kor	Sino-Korean
-lao	lao	Lao	Lao	Lao People's Democratic Republic	https://www.ethnologue.com/language/lao	
-lat	lat	Latin	Latin	World	https://www.ethnologue.com/language/lat	
-lav	lav	Latvian	Latin	Latvia	https://www.ethnologue.com/language/lav	
-lim	lim	Limburgish, Limburgan	Latin	Netherlands	https://www.ethnologue.com/language/lim	
-lit	lit	Lithuanian	Latin	Lithuania	https://www.ethnologue.com/language/lit	
-lmo	lmo	Lombard	Latin	Italy	https://www.ethnologue.com/language/lmo	
-ltz	ltz	Luxembourgish	Latin	Luxembourg	https://www.ethnologue.com/language/ltz	
-mad	mad	Madurese	Latin	Indonesia	https://www.ethnologue.com/language/mad	
-mag	mag	Magahi	Devanagari	India	https://www.ethnologue.com/language/mag	
-mai	mai	Maithili	Devanagari	India	https://www.ethnologue.com/language/mai	
-mak	mak	Makassarese, Makasar	Latin	Indonesia	https://www.ethnologue.com/language/mak	
-mal	mal	Malayalam	Malayalam	India	https://www.ethnologue.com/language/mal	
-mar	mar	Marathi	Devanagari	India	https://www.ethnologue.com/language/mar	
-mel	mel	Central Melanau	Latin	Malaysia	https://www.ethnologue.com/language/mel	
-min	min	Minangkabau	Latin	Indonesia	https://www.ethnologue.com/language/min	
-mkd	mkd	Macedonian	Cyrillic	Macedonia, the former Yugoslav Republic of	https://www.ethnologue.com/language/mkd	
-mlg	mlg	Malagasy	Latin	Madagascar	https://www.ethnologue.com/language/mlg	
-mlt	mlt	Maltese	Latin	Malta	https://www.ethnologue.com/language/mlt	
-mon	mon	Mongolian	Cyrillic	Mongolia	https://www.ethnologue.com/language/mon	
-mos	mos	Mossi, Mooré	Latin	Burkina Faso	https://www.ethnologue.com/language/mos	
-mri	mri	Maori	Latin	New Zealand	https://www.ethnologue.com/language/mri	
-mui	mui	Musi	Latin	Indonesia	https://www.ethnologue.com/language/mui	
-mup	mup	Malvi	Devanagari	India	https://www.ethnologue.com/language/mup	
-mwr	mwr	Marwari	Devanagari	India	https://www.ethnologue.com/language/mwr	
-mya	mya	Burmese, Myanmar	Myanmar	Myanmar	https://www.ethnologue.com/language/mya	
-nap	nap	Neapolitan, Napoletano-Calabrese	Latin	Italy	https://www.ethnologue.com/language/nap	
-nld	nld	Dutch	Latin	Netherlands	https://www.ethnologue.com/language/nld	
-npi	npi	Nepali	Devanagari	Nepal	https://www.ethnologue.com/language/npi	
-nso	nso	Northern Sotho, Pedi	Latin	South Africa	https://www.ethnologue.com/language/nso	
-nya	nya	Nyanja; Chewa; Chichewa, Nyanja, Chichewa	Latin	Malawi	https://www.ethnologue.com/language/nya	
-ori	ori	Oriya	Oriya	India	https://www.ethnologue.com/language/ori	
-orm	orm	Oromo	Latin	Ethiopia	https://www.ethnologue.com/language/orm	
-pag	pag	Pangasinan	Latin	Philippines	https://www.ethnologue.com/language/pag	
-pam	pam	Kapampangan, Pampanga	Latin	Philippines	https://www.ethnologue.com/language/pam	
-pcm	pcm	Nigerian Pidgin	Latin	Nigeria	https://www.ethnologue.com/language/pcm	
-pes	pes	Persian	Arabic	Iran, Islamic Republic of	https://www.ethnologue.com/language/pes	
-pnb	pnb_pk	Punjabi, Western Punjabi, Panjabi	Arabic	Pakistan	https://www.ethnologue.com/language/pnb	
-pnb	pnb_in	Punjabi, Western Punjabi, Panjabi	Gurmukhi	India	https://www.ethnologue.com/language/pnb	
-pol	pol	Polish	Latin	Poland	https://www.ethnologue.com/language/pol	
-por	por_br	Portuguese	Latin	Brazil	https://www.ethnologue.com/language/por	
-por	por_pt	Portuguese	Latin	Portugal	https://www.ethnologue.com/language/por	
-pus	pus	Pashto, Pushto	Arabic	Afghanistan	https://www.ethnologue.com/language/pus	
-que	que_quechua	Quechua	Latin	Peru	https://www.ethnologue.com/language/que	Quechua
-que	que_spanish	Quechua	Latin	Peru	https://www.ethnologue.com/language/que	Spanish
-rkt	rkt	Rangpuri	Bengali	Bangladesh	https://www.ethnologue.com/language/rkt	
-ron	ron	Romanian	Latin	Romania	https://www.ethnologue.com/language/ron	
-run	run	Rundi, Kirundi	Latin	Burundi	https://www.ethnologue.com/language/run	
-rus	rus	Russian	Cyrillic	Russian Federation	https://www.ethnologue.com/language/rus	
-san	san	Sanskrit	Devanagari	India	https://www.ethnologue.com/language/san	
-sas	sas	Sasak	Latin	Indonesia	https://www.ethnologue.com/language/sas	
-scn	scn	Sicilian	Latin	Italy	https://www.ethnologue.com/language/scn	
-sin	sin	Sinhala	Sinhala	Sri Lanka	https://www.ethnologue.com/language/sin	
-skr	skr_no_diacritics	Saraiki	Arabic	Pakistan	https://www.ethnologue.com/language/skr	without diacritics
-skr	skr_with_diacritics	Saraiki	Arabic	Pakistan	https://www.ethnologue.com/language/skr	with diacritics
-slk	slk	Slovak	Latin	Slovakia	https://www.ethnologue.com/language/slk	
-slv	slv	Slovenian	Latin	Slovenia	https://www.ethnologue.com/language/slv	
-smo	smo	Samoan	Latin	Samoa	https://www.ethnologue.com/language/smo	
-sna	sna	Shona	Latin	Zimbabwe	https://www.ethnologue.com/language/sna	
-snd	snd	Sindhi	Arabic	Pakistan	https://www.ethnologue.com/language/snd	
-som	som	Somali	Latin	Somalia	https://www.ethnologue.com/language/som	
-sot	sot	Sesotho, Southern Sotho	Latin	South Africa	https://www.ethnologue.com/language/sot	
-spa	spa	Spanish	Latin	Spain	https://www.ethnologue.com/language/spa	
-sqi	sqi	Albanian	Latin	Albania	https://www.ethnologue.com/language/sqi	
-srd	srd	Sardinian	Latin	Italy	https://www.ethnologue.com/language/srd	
-srp	srp	Serbian	Latin	Serbia	https://www.ethnologue.com/language/srp	
-sun	sun	Sundanese, Sunda	Latin	Indonesia	https://www.ethnologue.com/language/sun	
-swa	swa	Swahili	Latin	Kenya	https://www.ethnologue.com/language/swa	
-swe	swe	Swedish	Latin	Sweden	https://www.ethnologue.com/language/swe	
-syl	syl	Sylheti	Bengali	Bangladesh	https://www.ethnologue.com/language/syl	
-tam	tam	Tamil	Tamil	India	https://www.ethnologue.com/language/tam	
-tat	tat	Tatar	Cyrillic	Russian Federation	https://www.ethnologue.com/language/tat	
-tel	tel	Telugu	Telugu	India	https://www.ethnologue.com/language/tel	
-tgk	tgk	Tajik, Tajiki	Cyrillic	Tajikistan	https://www.ethnologue.com/language/tgk	
-tha	tha	Thai	Thai	Thailand	https://www.ethnologue.com/language/tha	
-tks	tks	Takestani	Arabic	Iran, Islamic Republic of	https://www.ethnologue.com/language/tks	
-tsn	tsn	Tswana, Setswana	Latin	Botswana	https://www.ethnologue.com/language/tsn	
-tts	tts	Northeastern Thai	Thai	Thailand	https://www.ethnologue.com/language/tts	
-tuk	tuk	Turkmen	Latin	Turkmenistan	https://www.ethnologue.com/language/tuk	
-tur	tur	Turkish	Latin	Turkey	https://www.ethnologue.com/language/tur	
-uig	uig	Uyghur, Uighur	Arabic	China	https://www.ethnologue.com/language/uig	
-ukr	ukr	Ukrainian	Cyrillic	Ukraine	https://www.ethnologue.com/language/ukr	
-urd	urd	Urdu	Arabic	Pakistan	https://www.ethnologue.com/language/urd	
-uzb	uzb	Uzbek	Latin	Uzbekistan	https://www.ethnologue.com/language/uzb	
-vec	vec	Venetian	Latin	Italy	https://www.ethnologue.com/language/vec	
-vie	vie_north	Vietnamese	Latin	Viet Nam	https://www.ethnologue.com/language/vie	North
-vie	vie_south	Vietnamese	Latin	Viet Nam	https://www.ethnologue.com/language/vie	South
-wne	wne	Wanetsi	Arabic	Pakistan	https://www.ethnologue.com/language/wne	
-wol	wol	Wolof	Latin	Senegal	https://www.ethnologue.com/language/wol	
-wrz	wrz	Waray	Latin	Philippines	https://www.ethnologue.com/language/wrz	
-xho	xho	isiXhosa, Xhosa	Latin	South Africa	https://www.ethnologue.com/language/xho	
-yid	yid	Yiddish	Hebrew	United States of America	https://www.ethnologue.com/language/yid	
-yor	yor	Yoruba	Latin	Nigeria	https://www.ethnologue.com/language/yor	
-yue	yue	Chinese, Cantonese, Yue Chinese	Han (Traditional variant)	Hong Kong	https://www.ethnologue.com/language/yue	
-zlm	zlm	Malay	Latin	Malaysia	https://www.ethnologue.com/language/zlm	
-zul	zul	Zulu	Latin	South Africa	https://www.ethnologue.com/language/zul	
+ISO 639-3	Code	Language name(s)	Script	Locale	Ethnologue	Variety	Glottocode	Glottolog
+ace	ace	Acehnese	Latin	Indonesia	https://www.ethnologue.com/language/ace		achi1257	https://glottolog.org/resource/languoid/id/achi1257
+afr	afr	Afrikaans	Latin	South Africa	https://www.ethnologue.com/language/afr		afri1274	https://glottolog.org/resource/languoid/id/afri1274
+aka	aka_akuapem	Akan	Latin	Ghana	https://www.ethnologue.com/language/aka	Akuapem	akan1250	https://glottolog.org/resource/languoid/id/akan1250
+aka	aka_asante	Akan	Latin	Ghana	https://www.ethnologue.com/language/aka	Asante	akan1250	https://glottolog.org/resource/languoid/id/akan1250
+amh	amh	Amharic	Ethiopic	Ethiopia	https://www.ethnologue.com/language/amh		amha1245	https://glottolog.org/resource/languoid/id/amha1245
+arb	arb	Arabic (MSA)	Arabic	World	https://www.ethnologue.com/language/arb	Modern Standard	stan1318	https://glottolog.org/resource/languoid/id/stan1318
+ary	ary_no_diacritics	Arabic	Arabic	Morocco	https://www.ethnologue.com/language/ary	without diacritics	moro1292	https://glottolog.org/resource/languoid/id/moro1292
+ary	ary_with_diacritics	Arabic	Arabic	Morocco	https://www.ethnologue.com/language/ary	with diacritics	moro1292	https://glottolog.org/resource/languoid/id/moro1292
+arz	arz	Arabic	Arabic	Egypt	https://www.ethnologue.com/language/arz		egyp1253	https://glottolog.org/resource/languoid/id/egyp1253
+asm	asm	Assamese	Bengali	India	https://www.ethnologue.com/language/asm		assa1263	https://glottolog.org/resource/languoid/id/assa1263
+awa	awa	Awadhi	Devanagari	India	https://www.ethnologue.com/language/awa		awad1243	https://glottolog.org/resource/languoid/id/awad1243
+aze	aze_az	Azerbaijani	Latin	Azerbaijan	https://www.ethnologue.com/language/aze			
+aze	aze_ir	Azerbaijani	Arabic	Iran, Islamic Republic of	https://www.ethnologue.com/language/aze			
+bam	bam	Bambara	Latin	Mali	https://www.ethnologue.com/language/bam		bamb1269	https://glottolog.org/resource/languoid/id/bamb1269
+ban	ban	Balinese	Latin	Indonesia	https://www.ethnologue.com/language/ban		bali1278	https://glottolog.org/resource/languoid/id/bali1278
+bar	bar	Bavarian	Latin	Austria	https://www.ethnologue.com/language/bar		bava1246	https://glottolog.org/resource/languoid/id/bava1246
+bbc	bbc	Batak Toba	Latin	Indonesia	https://www.ethnologue.com/language/bbc		bata1289	https://glottolog.org/resource/languoid/id/bata1289
+bel	bel	Belarusian, Belarusan	Cyrillic	Belarus	https://www.ethnologue.com/language/bel		bela1254	https://glottolog.org/resource/languoid/id/bela1254
+ben	ben	Bengali	Bengali	Bangladesh	https://www.ethnologue.com/language/ben		beng1280	https://glottolog.org/resource/languoid/id/beng1280
+bgc	bgc	Haryanvi	Devanagari	India	https://www.ethnologue.com/language/bgc		hary1238	https://glottolog.org/resource/languoid/id/hary1238
+bgn	bgn	Balochi, Baluchi	Arabic	Pakistan	https://www.ethnologue.com/language/bgn		west2368	https://glottolog.org/resource/languoid/id/west2368
+bho	bho	Bhojpuri	Devanagari	India	https://www.ethnologue.com/language/bho		bhoj1244	https://glottolog.org/resource/languoid/id/bhoj1244
+bjn	bjn	Banjar	Latin	Indonesia	https://www.ethnologue.com/language/bjn		banj1239	https://glottolog.org/resource/languoid/id/banj1239
+bmw	bmw	Norwegian Bokmål	Latin	Norway	https://www.ethnologue.com/language/bmw		bomw1238	https://glottolog.org/resource/languoid/id/bomw1238
+bod	bod	Tibetan	Tibetan	China	https://www.ethnologue.com/language/bod		tibe1272	https://glottolog.org/resource/languoid/id/tibe1272
+boy	boy	Bodo	Devanagari	India	https://www.ethnologue.com/language/boy		bodo1272	https://glottolog.org/resource/languoid/id/bodo1272
+bug	bug	Buginese	Latin	Indonesia	https://www.ethnologue.com/language/bug		bugi1244	https://glottolog.org/resource/languoid/id/bugi1244
+bul	bul	Bulgarian	Cyrillic	Bulgaria	https://www.ethnologue.com/language/bul		bulg1262	https://glottolog.org/resource/languoid/id/bulg1262
+cat	cat_es	Catalan	Latin	Spain	https://www.ethnologue.com/language/cat		stan1289	https://glottolog.org/resource/languoid/id/stan1289
+cat	cat_valencia	Catalan	Latin	Valencia	https://www.ethnologue.com/language/cat		stan1289	https://glottolog.org/resource/languoid/id/stan1289
+ceb	ceb_austronesian	Cebuano	Latin	Philippines	https://www.ethnologue.com/language/ceb	Austronesian	cebu1242	https://glottolog.org/resource/languoid/id/cebu1242
+ceb	ceb_spanish	Cebuano	Latin	Philippines	https://www.ethnologue.com/language/ceb	Spanish	cebu1242	https://glottolog.org/resource/languoid/id/cebu1242
+ces	ces	Czech	Latin	Czechia	https://www.ethnologue.com/language/ces		czec1258	https://glottolog.org/resource/languoid/id/czec1258
+ckb	ckb_arabic	Sorani, Kurdish	Arabic	Iraq	https://www.ethnologue.com/language/ckb		cent1972	https://glottolog.org/resource/languoid/id/cent1972
+ckb	ckb_latin	Sorani, Kurdish	Latin	Iraq	https://www.ethnologue.com/language/ckb		cent1972	https://glottolog.org/resource/languoid/id/cent1972
+cmn	cmn_simplified	Chinese, Mandarin, Mandarin Chinese	Han (Simplified variant)	China	https://www.ethnologue.com/language/cmn		mand1415	https://glottolog.org/resource/languoid/id/mand1415
+cmn	cmn_traditional	Taiwanese Mandarin	Han (Traditional variant)	Taiwan	https://www.ethnologue.com/language/cmn		mand1415	https://glottolog.org/resource/languoid/id/mand1415
+cos	cos	Corsican	Latin	France	https://www.ethnologue.com/language/cos		cors1241	https://glottolog.org/resource/languoid/id/cors1241
+ctg	ctg	Chittagonian	Bengali	Bangladesh	https://www.ethnologue.com/language/ctg		chit1275	https://glottolog.org/resource/languoid/id/chit1275
+cym	cym	Welsh	Latin	United Kingdom	https://www.ethnologue.com/language/cym		wels1247	https://glottolog.org/resource/languoid/id/wels1247
+dan	dan	Danish	Latin	Denmark	https://www.ethnologue.com/language/dan		dani1285	https://glottolog.org/resource/languoid/id/dani1285
+dcc	dcc	Deccan	Arabic	India	https://www.ethnologue.com/language/dcc		decc1239	https://glottolog.org/resource/languoid/id/decc1239
+deu	deu	German	Latin	Germany	https://www.ethnologue.com/language/deu		stan1295	https://glottolog.org/resource/languoid/id/stan1295
+dgo	dgo	Dogri	Devanagari	India	https://www.ethnologue.com/language/dgo		dogr1250	https://glottolog.org/resource/languoid/id/dogr1250
+dzo	dzo	Dzongkha	Tibetan	Bhutan	https://www.ethnologue.com/language/dzo		dzon1239	https://glottolog.org/resource/languoid/id/dzon1239
+ell	ell	Greek	Greek	Greece	https://www.ethnologue.com/language/ell		mode1248	https://glottolog.org/resource/languoid/id/mode1248
+eng	eng_in	English	Latin	India	https://www.ethnologue.com/language/eng		stan1293	https://glottolog.org/resource/languoid/id/stan1293
+eng	eng_us	English	Latin	United States of America	https://www.ethnologue.com/language/eng		stan1293	https://glottolog.org/resource/languoid/id/stan1293
+epo	epo	Esperanto	Latin	World	https://www.ethnologue.com/language/epo		espe1235	https://glottolog.org/resource/languoid/id/espe1235
+est	est	Estonian	Latin	Estonia	https://www.ethnologue.com/language/est			
+eus	eus	Basque	Latin	Spain	https://www.ethnologue.com/language/eus		basq1248	https://glottolog.org/resource/languoid/id/basq1248
+fil	fil	Tagalog	Latin	Philippines	https://www.ethnologue.com/language/tgl		fili1244	https://glottolog.org/resource/languoid/id/fili1244
+fin	fin	Finnish	Latin	Finland	https://www.ethnologue.com/language/fin		finn1318	https://glottolog.org/resource/languoid/id/finn1318
+fra	fra_ch	French	Latin	Switzerland	https://www.ethnologue.com/language/fra		stan1290	https://glottolog.org/resource/languoid/id/stan1290
+fra	fra_fr	French	Latin	France	https://www.ethnologue.com/language/fra		stan1290	https://glottolog.org/resource/languoid/id/stan1290
+fry	fry	Western Frisian	Latin	Netherlands	https://www.ethnologue.com/language/fry		west2354	https://glottolog.org/resource/languoid/id/west2354
+ful	ful	Fulah	Latin	West Africa	https://www.ethnologue.com/language/ful		fula1264	https://glottolog.org/resource/languoid/id/fula1264
+gla	gla	Scottish Gaelic	Latin	United Kingdom	https://www.ethnologue.com/language/gla		scot1245	https://glottolog.org/resource/languoid/id/scot1245
+gle	gle	Irish	Latin	Ireland	https://www.ethnologue.com/language/gle		iris1253	https://glottolog.org/resource/languoid/id/iris1253
+glg	glg	Galician	Latin	Spain	https://www.ethnologue.com/language/glg		gali1258	https://glottolog.org/resource/languoid/id/gali1258
+grn	grn	Guarani, Guaraní	Latin	Paraguay	https://www.ethnologue.com/language/grn			
+guj	guj	Gujarati	Gujarati	India	https://www.ethnologue.com/language/guj		guja1252	https://glottolog.org/resource/languoid/id/guja1252
+hat	hat	Haitian	Latin	Haiti	https://www.ethnologue.com/language/hat		hait1244	https://glottolog.org/resource/languoid/id/hait1244
+hau	hau	Hausa	Latin	Nigeria	https://www.ethnologue.com/language/hau		haus1257	https://glottolog.org/resource/languoid/id/haus1257
+haw	haw	Hawaiian	Latin	United States of America	https://www.ethnologue.com/language/haw		hawa1245	https://glottolog.org/resource/languoid/id/hawa1245
+heb	heb_no_diacritics	Hebrew	Hebrew	Israel	https://www.ethnologue.com/language/heb	without diacritics	hebr1245	https://glottolog.org/resource/languoid/id/hebr1245
+heb	heb_with_diacritics	Hebrew	Hebrew	Israel	https://www.ethnologue.com/language/heb	with diacritics	hebr1245	https://glottolog.org/resource/languoid/id/hebr1245
+hil	hil	Hiligaynon	Latin	Philippines	https://www.ethnologue.com/language/hil		hili1240	https://glottolog.org/resource/languoid/id/hili1240
+hin	hin	Hindi	Devanagari	India	https://www.ethnologue.com/language/hin		hind1269	https://glottolog.org/resource/languoid/id/hind1269
+hmn	hmn	Hmong	Latin	China	https://www.ethnologue.com/language/hmn			
+hne	hne	Chhattisgarhi	Devanagari	India	https://www.ethnologue.com/language/hne		chha1249	https://glottolog.org/resource/languoid/id/chha1249
+hoj	hoj	Harauti	Devanagari	India	https://www.ethnologue.com/language/hoj		hado1235	https://glottolog.org/resource/languoid/id/hado1235
+hrv	hrv	Croatian	Latin	Croatia	https://www.ethnologue.com/language/hrv		croa1245	https://glottolog.org/resource/languoid/id/croa1245
+hun	hun	Hungarian	Latin	Hungary	https://www.ethnologue.com/language/hun		hung1274	https://glottolog.org/resource/languoid/id/hung1274
+hye	hye	Armenian	Armenian	Armenia	https://www.ethnologue.com/language/hye		nucl1235	https://glottolog.org/resource/languoid/id/nucl1235
+ibo	ibo	Igbo	Latin	Nigeria	https://www.ethnologue.com/language/ibo		nucl1417	https://glottolog.org/resource/languoid/id/nucl1417
+ilo	ilo	Ilocano, Iloko	Latin	Philippines	https://www.ethnologue.com/language/ilo		ilok1237	https://glottolog.org/resource/languoid/id/ilok1237
+ind	ind	Indonesian	Latin	Indonesia	https://www.ethnologue.com/language/ind		indo1316	https://glottolog.org/resource/languoid/id/indo1316
+isl	isl	Icelandic	Latin	Iceland	https://www.ethnologue.com/language/isl		icel1247	https://glottolog.org/resource/languoid/id/icel1247
+ita	ita	Italian	Latin	Italy	https://www.ethnologue.com/language/ita		ital1282	https://glottolog.org/resource/languoid/id/ital1282
+jav	jav	Javanese	Latin	Indonesia	https://www.ethnologue.com/language/jav		java1254	https://glottolog.org/resource/languoid/id/java1254
+jpn	jpn	Japanese	Japanese	Japan	https://www.ethnologue.com/language/jpn		nucl1643	https://glottolog.org/resource/languoid/id/nucl1643
+kan	kan	Kannada	Kannada	India	https://www.ethnologue.com/language/kan		nucl1305	https://glottolog.org/resource/languoid/id/nucl1305
+kas	kas	Kashmiri	Devanagari	India	https://www.ethnologue.com/language/kas		kash1277	https://glottolog.org/resource/languoid/id/kash1277
+kat	kat	Georgian	Georgian	Georgia	https://www.ethnologue.com/language/kat		nucl1302	https://glottolog.org/resource/languoid/id/nucl1302
+kaz	kaz	Kazakh	Cyrillic	Kazakhstan	https://www.ethnologue.com/language/kaz		kaza1248	https://glottolog.org/resource/languoid/id/kaza1248
+khm	khm	Khmer, Central Khmer	Khmer	Cambodia	https://www.ethnologue.com/language/khm		cent1989	https://glottolog.org/resource/languoid/id/cent1989
+kin	kin	Kinyarwanda	Latin	Rwanda	https://www.ethnologue.com/language/kin		kiny1244	https://glottolog.org/resource/languoid/id/kiny1244
+kir	kir	Kyrgyz, Kirghiz	Cyrillic	Kyrgyzstan	https://www.ethnologue.com/language/kir		kirg1245	https://glottolog.org/resource/languoid/id/kirg1245
+kok	kok	Konkani	Devanagari	India	https://www.ethnologue.com/language/kok		konk1270	https://glottolog.org/resource/languoid/id/konk1270
+kor	kor	Korean	Hangul	Korea, Republic of	https://www.ethnologue.com/language/kor	Sino-Korean	kore1280	https://glottolog.org/resource/languoid/id/kore1280
+lao	lao	Lao	Lao	Lao People's Democratic Republic	https://www.ethnologue.com/language/lao		laoo1244	https://glottolog.org/resource/languoid/id/laoo1244
+lat	lat	Latin	Latin	World	https://www.ethnologue.com/language/lat		lati1261	https://glottolog.org/resource/languoid/id/lati1261
+lav	lav	Latvian	Latin	Latvia	https://www.ethnologue.com/language/lav		latv1249	https://glottolog.org/resource/languoid/id/latv1249
+lim	lim	Limburgish, Limburgan	Latin	Netherlands	https://www.ethnologue.com/language/lim		limb1263	https://glottolog.org/resource/languoid/id/limb1263
+lit	lit	Lithuanian	Latin	Lithuania	https://www.ethnologue.com/language/lit		lith1251	https://glottolog.org/resource/languoid/id/lith1251
+lmo	lmo	Lombard	Latin	Italy	https://www.ethnologue.com/language/lmo		lomb1257	https://glottolog.org/resource/languoid/id/lomb1257
+ltz	ltz	Luxembourgish	Latin	Luxembourg	https://www.ethnologue.com/language/ltz		luxe1241	https://glottolog.org/resource/languoid/id/luxe1241
+mad	mad	Madurese	Latin	Indonesia	https://www.ethnologue.com/language/mad		nucl1460	https://glottolog.org/resource/languoid/id/nucl1460
+mag	mag	Magahi	Devanagari	India	https://www.ethnologue.com/language/mag		maga1260	https://glottolog.org/resource/languoid/id/maga1260
+mai	mai	Maithili	Devanagari	India	https://www.ethnologue.com/language/mai		mait1250	https://glottolog.org/resource/languoid/id/mait1250
+mak	mak	Makassarese, Makasar	Latin	Indonesia	https://www.ethnologue.com/language/mak		maka1311	https://glottolog.org/resource/languoid/id/maka1311
+mal	mal	Malayalam	Malayalam	India	https://www.ethnologue.com/language/mal		mala1464	https://glottolog.org/resource/languoid/id/mala1464
+mar	mar	Marathi	Devanagari	India	https://www.ethnologue.com/language/mar		mara1378	https://glottolog.org/resource/languoid/id/mara1378
+mel	mel	Central Melanau	Latin	Malaysia	https://www.ethnologue.com/language/mel		cent2101	https://glottolog.org/resource/languoid/id/cent2101
+min	min	Minangkabau	Latin	Indonesia	https://www.ethnologue.com/language/min		mina1268	https://glottolog.org/resource/languoid/id/mina1268
+mkd	mkd	Macedonian	Cyrillic	Macedonia, the former Yugoslav Republic of	https://www.ethnologue.com/language/mkd		mace1250	https://glottolog.org/resource/languoid/id/mace1250
+mlg	mlg	Malagasy	Latin	Madagascar	https://www.ethnologue.com/language/mlg			
+mlt	mlt	Maltese	Latin	Malta	https://www.ethnologue.com/language/mlt		malt1254	https://glottolog.org/resource/languoid/id/malt1254
+mon	mon	Mongolian	Cyrillic	Mongolia	https://www.ethnologue.com/language/mon		mong1331	https://glottolog.org/resource/languoid/id/mong1331
+mos	mos	Mossi, Mooré	Latin	Burkina Faso	https://www.ethnologue.com/language/mos		moss1236	https://glottolog.org/resource/languoid/id/moss1236
+mri	mri	Maori	Latin	New Zealand	https://www.ethnologue.com/language/mri		maor1246	https://glottolog.org/resource/languoid/id/maor1246
+mui	mui	Musi	Latin	Indonesia	https://www.ethnologue.com/language/mui		musi1241	https://glottolog.org/resource/languoid/id/musi1241
+mup	mup	Malvi	Devanagari	India	https://www.ethnologue.com/language/mup		malv1243	https://glottolog.org/resource/languoid/id/malv1243
+mwr	mwr	Marwari	Devanagari	India	https://www.ethnologue.com/language/mwr			
+mya	mya	Burmese, Myanmar	Myanmar	Myanmar	https://www.ethnologue.com/language/mya		nucl1310	https://glottolog.org/resource/languoid/id/nucl1310
+nap	nap	Neapolitan, Napoletano-Calabrese	Latin	Italy	https://www.ethnologue.com/language/nap		neap1235	https://glottolog.org/resource/languoid/id/neap1235
+nld	nld	Dutch	Latin	Netherlands	https://www.ethnologue.com/language/nld		dutc1256	https://glottolog.org/resource/languoid/id/dutc1256
+npi	npi	Nepali	Devanagari	Nepal	https://www.ethnologue.com/language/npi		nepa1254	https://glottolog.org/resource/languoid/id/nepa1254
+nso	nso	Northern Sotho, Pedi	Latin	South Africa	https://www.ethnologue.com/language/nso		pedi1238	https://glottolog.org/resource/languoid/id/pedi1238
+nya	nya	Nyanja; Chewa; Chichewa, Nyanja, Chichewa	Latin	Malawi	https://www.ethnologue.com/language/nya		nyan1308	https://glottolog.org/resource/languoid/id/nyan1308
+ori	ori	Oriya	Oriya	India	https://www.ethnologue.com/language/ori			
+orm	orm	Oromo	Latin	Ethiopia	https://www.ethnologue.com/language/orm			
+pag	pag	Pangasinan	Latin	Philippines	https://www.ethnologue.com/language/pag		pang1290	https://glottolog.org/resource/languoid/id/pang1290
+pam	pam	Kapampangan, Pampanga	Latin	Philippines	https://www.ethnologue.com/language/pam		pamp1243	https://glottolog.org/resource/languoid/id/pamp1243
+pcm	pcm	Nigerian Pidgin	Latin	Nigeria	https://www.ethnologue.com/language/pcm		nige1257	https://glottolog.org/resource/languoid/id/nige1257
+pes	pes	Persian	Arabic	Iran, Islamic Republic of	https://www.ethnologue.com/language/pes		west2369	https://glottolog.org/resource/languoid/id/west2369
+pnb	pnb_pk	Punjabi, Western Punjabi, Panjabi	Arabic	Pakistan	https://www.ethnologue.com/language/pnb		west2386	https://glottolog.org/resource/languoid/id/west2386
+pnb	pnb_in	Punjabi, Western Punjabi, Panjabi	Gurmukhi	India	https://www.ethnologue.com/language/pnb		west2386	https://glottolog.org/resource/languoid/id/west2386
+pol	pol	Polish	Latin	Poland	https://www.ethnologue.com/language/pol		poli1260	https://glottolog.org/resource/languoid/id/poli1260
+por	por_br	Portuguese	Latin	Brazil	https://www.ethnologue.com/language/por		port1283	https://glottolog.org/resource/languoid/id/port1283
+por	por_pt	Portuguese	Latin	Portugal	https://www.ethnologue.com/language/por		port1283	https://glottolog.org/resource/languoid/id/port1283
+pus	pus	Pashto, Pushto	Arabic	Afghanistan	https://www.ethnologue.com/language/pus		nucl1276	https://glottolog.org/resource/languoid/id/nucl1276
+que	que_quechua	Quechua	Latin	Peru	https://www.ethnologue.com/language/que	Quechua		
+que	que_spanish	Quechua	Latin	Peru	https://www.ethnologue.com/language/que	Spanish		
+rkt	rkt	Rangpuri	Bengali	Bangladesh	https://www.ethnologue.com/language/rkt		rang1265	https://glottolog.org/resource/languoid/id/rang1265
+ron	ron	Romanian	Latin	Romania	https://www.ethnologue.com/language/ron		roma1327	https://glottolog.org/resource/languoid/id/roma1327
+run	run	Rundi, Kirundi	Latin	Burundi	https://www.ethnologue.com/language/run		rund1242	https://glottolog.org/resource/languoid/id/rund1242
+rus	rus	Russian	Cyrillic	Russian Federation	https://www.ethnologue.com/language/rus		russ1263	https://glottolog.org/resource/languoid/id/russ1263
+san	san	Sanskrit	Devanagari	India	https://www.ethnologue.com/language/san		sans1269	https://glottolog.org/resource/languoid/id/sans1269
+sas	sas	Sasak	Latin	Indonesia	https://www.ethnologue.com/language/sas		sasa1249	https://glottolog.org/resource/languoid/id/sasa1249
+scn	scn	Sicilian	Latin	Italy	https://www.ethnologue.com/language/scn		sici1248	https://glottolog.org/resource/languoid/id/sici1248
+sin	sin	Sinhala	Sinhala	Sri Lanka	https://www.ethnologue.com/language/sin		sinh1246	https://glottolog.org/resource/languoid/id/sinh1246
+skr	skr_no_diacritics	Saraiki	Arabic	Pakistan	https://www.ethnologue.com/language/skr	without diacritics	sera1259	https://glottolog.org/resource/languoid/id/sera1259
+skr	skr_with_diacritics	Saraiki	Arabic	Pakistan	https://www.ethnologue.com/language/skr	with diacritics	sera1259	https://glottolog.org/resource/languoid/id/sera1259
+slk	slk	Slovak	Latin	Slovakia	https://www.ethnologue.com/language/slk		slov1269	https://glottolog.org/resource/languoid/id/slov1269
+slv	slv	Slovenian	Latin	Slovenia	https://www.ethnologue.com/language/slv		slov1268	https://glottolog.org/resource/languoid/id/slov1268
+smo	smo	Samoan	Latin	Samoa	https://www.ethnologue.com/language/smo		samo1305	https://glottolog.org/resource/languoid/id/samo1305
+sna	sna	Shona	Latin	Zimbabwe	https://www.ethnologue.com/language/sna		shon1251	https://glottolog.org/resource/languoid/id/shon1251
+snd	snd	Sindhi	Arabic	Pakistan	https://www.ethnologue.com/language/snd		sind1272	https://glottolog.org/resource/languoid/id/sind1272
+som	som	Somali	Latin	Somalia	https://www.ethnologue.com/language/som		soma1255	https://glottolog.org/resource/languoid/id/soma1255
+sot	sot	Sesotho, Southern Sotho	Latin	South Africa	https://www.ethnologue.com/language/sot		sout2807	https://glottolog.org/resource/languoid/id/sout2807
+spa	spa	Spanish	Latin	Spain	https://www.ethnologue.com/language/spa		stan1288	https://glottolog.org/resource/languoid/id/stan1288
+sqi	sqi	Albanian	Latin	Albania	https://www.ethnologue.com/language/sqi		alba1267	https://glottolog.org/resource/languoid/id/alba1267
+srd	srd	Sardinian	Latin	Italy	https://www.ethnologue.com/language/srd			
+srp	srp	Serbian	Latin	Serbia	https://www.ethnologue.com/language/srp		serb1264	https://glottolog.org/resource/languoid/id/serb1264
+sun	sun	Sundanese, Sunda	Latin	Indonesia	https://www.ethnologue.com/language/sun		sund1252	https://glottolog.org/resource/languoid/id/sund1252
+swa	swa	Swahili	Latin	Kenya	https://www.ethnologue.com/language/swa			
+swe	swe	Swedish	Latin	Sweden	https://www.ethnologue.com/language/swe		swed1254	https://glottolog.org/resource/languoid/id/swed1254
+syl	syl	Sylheti	Bengali	Bangladesh	https://www.ethnologue.com/language/syl		sylh1242	https://glottolog.org/resource/languoid/id/sylh1242
+tam	tam	Tamil	Tamil	India	https://www.ethnologue.com/language/tam		tami1289	https://glottolog.org/resource/languoid/id/tami1289
+tat	tat	Tatar	Cyrillic	Russian Federation	https://www.ethnologue.com/language/tat		tata1255	https://glottolog.org/resource/languoid/id/tata1255
+tel	tel	Telugu	Telugu	India	https://www.ethnologue.com/language/tel		telu1262	https://glottolog.org/resource/languoid/id/telu1262
+tgk	tgk	Tajik, Tajiki	Cyrillic	Tajikistan	https://www.ethnologue.com/language/tgk		taji1245	https://glottolog.org/resource/languoid/id/taji1245
+tha	tha	Thai	Thai	Thailand	https://www.ethnologue.com/language/tha		thai1261	https://glottolog.org/resource/languoid/id/thai1261
+tks	tks	Takestani	Arabic	Iran, Islamic Republic of	https://www.ethnologue.com/language/tks		take1255	https://glottolog.org/resource/languoid/id/take1255
+tsn	tsn	Tswana, Setswana	Latin	Botswana	https://www.ethnologue.com/language/tsn		tswa1253	https://glottolog.org/resource/languoid/id/tswa1253
+tts	tts	Northeastern Thai	Thai	Thailand	https://www.ethnologue.com/language/tts		nort2741	https://glottolog.org/resource/languoid/id/nort2741
+tuk	tuk	Turkmen	Latin	Turkmenistan	https://www.ethnologue.com/language/tuk		turk1304	https://glottolog.org/resource/languoid/id/turk1304
+tur	tur	Turkish	Latin	Turkey	https://www.ethnologue.com/language/tur		nucl1301	https://glottolog.org/resource/languoid/id/nucl1301
+uig	uig	Uyghur, Uighur	Arabic	China	https://www.ethnologue.com/language/uig		uigh1240	https://glottolog.org/resource/languoid/id/uigh1240
+ukr	ukr	Ukrainian	Cyrillic	Ukraine	https://www.ethnologue.com/language/ukr		ukra1253	https://glottolog.org/resource/languoid/id/ukra1253
+urd	urd	Urdu	Arabic	Pakistan	https://www.ethnologue.com/language/urd		urdu1245	https://glottolog.org/resource/languoid/id/urdu1245
+uzb	uzb	Uzbek	Latin	Uzbekistan	https://www.ethnologue.com/language/uzb		uzbe1247	https://glottolog.org/resource/languoid/id/uzbe1247
+vec	vec	Venetian	Latin	Italy	https://www.ethnologue.com/language/vec		vene1258	https://glottolog.org/resource/languoid/id/vene1258
+vie	vie_north	Vietnamese	Latin	Viet Nam	https://www.ethnologue.com/language/vie	North	viet1252	https://glottolog.org/resource/languoid/id/viet1252
+vie	vie_south	Vietnamese	Latin	Viet Nam	https://www.ethnologue.com/language/vie	South	viet1252	https://glottolog.org/resource/languoid/id/viet1252
+wne	wne	Wanetsi	Arabic	Pakistan	https://www.ethnologue.com/language/wne		wane1241	https://glottolog.org/resource/languoid/id/wane1241
+wol	wol	Wolof	Latin	Senegal	https://www.ethnologue.com/language/wol		nucl1347	https://glottolog.org/resource/languoid/id/nucl1347
+wrz	wrz	Waray	Latin	Philippines	https://www.ethnologue.com/language/wrz		wara1290	https://glottolog.org/resource/languoid/id/wara1290
+xho	xho	isiXhosa, Xhosa	Latin	South Africa	https://www.ethnologue.com/language/xho		xhos1239	https://glottolog.org/resource/languoid/id/xhos1239
+yid	yid	Yiddish	Hebrew	United States of America	https://www.ethnologue.com/language/yid		yidd1255	https://glottolog.org/resource/languoid/id/yidd1255
+yor	yor	Yoruba	Latin	Nigeria	https://www.ethnologue.com/language/yor		yoru1245	https://glottolog.org/resource/languoid/id/yoru1245
+yue	yue	Chinese, Cantonese, Yue Chinese	Han (Traditional variant)	Hong Kong	https://www.ethnologue.com/language/yue		yuec1235	https://glottolog.org/resource/languoid/id/yuec1235
+zlm	zlm	Malay	Latin	Malaysia	https://www.ethnologue.com/language/zlm		mala1479	https://glottolog.org/resource/languoid/id/mala1479
+zul	zul	Zulu	Latin	South Africa	https://www.ethnologue.com/language/zul		zulu1248	https://glottolog.org/resource/languoid/id/zulu1248


### PR DESCRIPTION
Hello,

if wanted, this adds Glottolog information (https://glottolog.org/) to `codes.tsv` wherever applicable (i.e. where matching ISO 639-3 exist). If not, feel free to ignore. :) At any rate, thanks for this awesome project!

For reference, this was generated with:

```python
from pyglottolog import Glottolog
from pandas import read_table
import csv

GL_REPO = "/PATH/TO/GLOTTOLOG"
UNINUM = "/PATH/TO/codes.tsv"
GL_URL = "https://glottolog.org/resource/languoid/id/"

glottolog = Glottolog(GL_REPO)
languoids = {l.id: l for l in glottolog.languoids()}

uniNum = read_table(UNINUM)
uniNum["Glottocode"] = ""
uniNum["Glottolog"] = ""

for i, row in uniNum.iterrows():
    for l in languoids.values():
        if l.iso == row["ISO 639-3"]:
            uniNum.at[i, "Glottocode"] = l.glottocode
            uniNum.at[i, "Glottolog"] = GL_URL + l.glottocode

uniNum.to_csv("codes.tsv", index=False, sep="\t", quoting=csv.QUOTE_NONE)
```