### PR TITLE
Update cat_valencia.tsv

### DIFF
--- a/numbers/cat_valencia.tsv
+++ b/numbers/cat_valencia.tsv
@@ -15,89 +15,89 @@
 14	catorze
 15	quinze
 16	setze
-17	disset, dèsset
+17	dèsset, disset
 18	dihuit, divuit
-19	dinou, dènou
+19	dènou, dinou
 20	vint
-21	vint i un
-22	vint i dos
-23	vint i tres
-24	vint i quatre
-25	vint i cinc
-26	vint i sis
-27	vint i set
-28	vint i huit
-29	vint i nou
+21	vint-i-u, vint-i-un, vint-i-una
+22	vint-i-dos, vint-i-dues
+23	vint-i-tres
+24	vint-i-quatre
+25	vint-i-cinc
+26	vint-i-sis
+27	vint-i-set
+28	vint-i-huit, vint-i-vuit
+29	vint-i-nou
 30	trenta
-31	trenta un
-32	trenta dos
-33	trenta tres
-34	trenta quatre
-35	trenta cinc
-36	trenta sis
-37	trenta set
-38	trenta huit
-39	trenta nou
+31	trenta-u, trenta-un, trenta-una
+32	trenta-dos, trenta-dues
+33	trenta-tres
+34	trenta-quatre
+35	trenta-cinc
+36	trenta-sis
+37	trenta-set
+38	trenta-huit, trenta-vuit
+39	trenta-nou
 40	quaranta
-41	quaranta un
-42	quaranta dos
-43	quaranta tres
-44	quaranta quatre
-45	quaranta cinc
-46	quaranta sis
-47	quaranta set
-48	quaranta huit
-49	quaranta nou
+41	quaranta-u, quaranta-un, quaranta-una
+42	quaranta-dos, quaranta-dues
+43	quaranta-tres
+44	quaranta-quatre
+45	quaranta-cinc
+46	quaranta-sis
+47	quaranta-set
+48	quaranta-huit, quaranta-vuit
+49	quaranta-nou
 50	cinquanta
-51	cinquanta un
-52	cinquanta dos
-53	cinquanta tres
-54	cinquanta quatre
-55	cinquanta cinc
-56	cinquanta sis
-57	cinquanta set
-58	cinquanta huit
-59	cinquanta nou
+51	cinquanta-u, cinquanta-un, cinquanta-una
+52	cinquanta-dos, cinquanta-dues
+53	cinquanta-tres
+54	cinquanta-quatre
+55	cinquanta-cinc
+56	cinquanta-sis
+57	cinquanta-set
+58	cinquanta-huit, cinquanta-vuit
+59	cinquanta-nou
 60	seixanta
-61	seixanta un
-62	seixanta dos
-63	seixanta tres
-64	seixanta quatre
-65	seixanta cinc
-66	seixanta sis
-67	seixanta set
-68	seixanta huit
-69	seixanta nou
+61	seixanta-u, seixanta-un, seixanta-una
+62	seixanta-dos, seixanta-dues
+63	seixanta-tres
+64	seixanta-quatre
+65	seixanta-cinc
+66	seixanta-sis
+67	seixanta-set
+68	seixanta-huit, seixanta-vuit
+69	seixanta-nou
 70	setanta
-71	setanta un
-72	setanta dos
-73	setanta tres
-74	setanta quatre
-75	setanta cinc
-76	setanta sis
-77	setanta set
-78	setanta huit
-79	setanta nou
+71	setanta-u, setanta-un, setanta-una
+72	setanta-dos, setanta-dues
+73	setanta-tres
+74	setanta-quatre
+75	setanta-cinc
+76	setanta-sis
+77	setanta-set
+78	setanta-huit, setanta-vuit
+79	setanta-nou
 80	huitanta, vuitanta
-81	huitanta un
-82	huitanta dos
-83	huitanta tres
-84	huitanta quatre
-85	huitanta cinc
-86	huitanta sis
-87	huitanta set
-88	huitanta huit
-89	huitanta nou
+81	huitanta-u, huitanta-un, huitanta-una, vuitanta-u, vuitanta-un, vuitanta-una
+82	huitanta-dos, huitanta-dues, vuitanta-dos, vuitanta-dues
+83	huitanta-tres, vuitanta-tres
+84	huitanta-quatre, vuitanta-quatre
+85	huitanta-cinc, vuitanta-cinc
+86	huitanta-sis, vuitanta-sis
+87	huitanta-set, vuitanta-set
+88	huitanta-huit, vuitanta-vuit
+89	huitanta-nou, vuitanta-nou
 90	noranta
-91	noranta un
-92	noranta dos
-93	noranta tres
-94	noranta quatre
-95	noranta cinc
-96	noranta sis
-97	noranta set
-98	noranta huit
-99	noranta nou
+91	noranta-u, noranta-un, noranta-una
+92	noranta-dos
+93	noranta-tres
+94	noranta-quatre
+95	noranta-cinc
+96	noranta-sis
+97  noranta-set
+98	noranta-huit, noranta-vuit
+99	noranta-nou
 100	cent
 1000	mil
 10000	deu mil
@@ -105,6 +105,6 @@
 1000000	un milió
 10000000	deu milions
 100000000	cent milions
-1000000000	un bilió
-10000000000	deu bilions
-100000000000	cent bilions
+1000000000	un miliard, mil milions
+10000000000	deu miliards, deu mil milions
+100000000000	cent miliards, cent mil milions


### PR DESCRIPTION
Fixed numbers from 21 to 99, hyphen must be used.
Keep alternative forms for 8, 18 and 8[0-9] forms (huit and vuit forms are good)
Added feminine form for numbers ended with 1 or 2, but 11 and 12 (una, dues, vint-i-una, vint-i-dues,...)
Added alternate masculine form for numbers ended with 1, but 11 (u, vint-i-u, trenta-u,...).
Fixed 10^[9,10,11], because Catalan/Valencian uses long scale (one billion is equal to 10^12)