### PR TITLE
Oromo [orm]: Corrected errors for Oromo language

### DIFF
--- a/numbers/orm.tsv
+++ b/numbers/orm.tsv
@@ -1,90 +1,90 @@
-0	duwwa
+0	duwwaa
 1	tokko
 2	lama
-3	sadii
+3	sadi
 4	afur
 5	shan
-6	jaa'a
+6	ja'a
 7	torba
 8	saddeet
 9	sagal
-10	khudan
-11	khuda tokko
-12	khuda lama
-13	khuda sadii
-14	khuda afur
-15	khuda shan
-16	khuda jaa'a
-17	khuda torba
-18	khuda saddeet
-19	khuda sagal
+10	kudhan
+11	kudha tokko
+12	kudha lama
+13	kudha sadi
+14	kudha afur
+15	kudha shan
+16	kudha ja'a
+17	kudha torba
+18	kudha saddeet
+19	kudha sagal
 20	digdama
 21	digdamii tokko
 22	digdamii lama
-23	digdamii sadii
+23	digdamii sadi
 24	digdamii afur
 25	digdamii shan
-26	digdamii jaa'a
+26	digdamii ja'a
 27	digdamii torba
 28	digdamii saddeet
 29	digdamii sagal
 30	soddoma
 31	soddomii tokko
 32	soddomii lama
-33	soddomii sadii
+33	soddomii sadi
 34	soddomii afur
 35	soddomii shan
-36	soddomii jaa'a
+36	soddomii ja'a
 37	soddomii torba
 38	soddomii saddeet
 39	soddomii sagal
 40	afurtama
 41	afurtamii tokko
 42	afurtamii lama
-43	afurtamii sadii
+43	afurtamii sadi
 44	afurtamii afur
 45	afurtamii shan
-46	afurtamii jaa'a
+46	afurtamii ja'a
 47	afurtamii torba
 48	afurtamii saddeet
 49	afurtamii sagal
 50	shantama
 51	shantamii tokko
 52	shantamii lama
-53	shantamii sadii
+53	shantamii sadi
 54	shantamii afur
 55	shantamii shan
-56	shantamii jaa'a
+56	shantamii ja'a
 57	shantamii torba
 58	shantamii saddeet
 59	shantamii sagal
 60	jaatama
 61	jaatamii tokko
 62	jaatamii lama
-63	jaatamii sadii
+63	jaatamii sadi
 64	jaatamii afur
 65	jaatamii shan
-66	jaatamii jaa'a
+66	jaatamii ja'a
 67	jaatamii torba
 68	jaatamii saddeet
 69	jaatamii sagal
 70	torbaatama
 71	torbaatamii tokko
 72	torbaatamii lama
-73	torbaatamii sadii
+73	torbaatamii sadi
 74	torbaatamii afur
 75	torbaatamii shan
-76	torbaatamii jaa'a
+76	torbaatamii ja'a
 77	torbaatamii torba
 78	torbaatamii saddeet
 79	torbaatamii sagal
 80	saddeettama
 81	saddeettamii tokko
 82	saddeettamii lama
-83	saddeettamii sadii
+83	saddeettamii sadi
 84	saddeettamii afur
 85	saddeettamii shan
-86	saddeettamii jaa'a
+86	saddeettamii ja'a
 87	saddeettamii torba
 88	saddeettamii saddeet
 89	saddeettamii sagal
@@ -94,17 +94,17 @@
 93	sagaltamii sadii
 94	sagaltamii afur
 95	sagaltamii shan
-96	sagaltamii jaa'a
+96	sagaltamii ja'a
 97	sagaltamii torba
 98	sagaltamii saddeet
 99	sagaltamii sagal
 100	dhibba tokko
 1000	kuma tokko
-10000	kuma khudan
+10000	kuma kudhan
 100000	kuma dhibba tokko
-1000000	millyoona tokko
-10000000	millyoona khudan
-100000000	millyoona dhibba tokko
-1000000000	billyoona tokko
-10000000000	billyoona khudan
-100000000000	billyoona dhibba tokko
+1000000	miliyoona tokko
+10000000	miliyoona kudhan
+100000000	miliyoona dhibba tokko
+1000000000	biliyoona tokko
+10000000000	biliyoona kudhan
+100000000000	biliyoona dhibba tokko


### PR DESCRIPTION
Mainly spelling errors.